### PR TITLE
Handle case when Sidekiq::Testing is disabled

### DIFF
--- a/lib/rspec/sidekiq/matchers/have_enqueued_job.rb
+++ b/lib/rspec/sidekiq/matchers/have_enqueued_job.rb
@@ -16,13 +16,18 @@ module RSpec
 
         def failure_message
           "expected to have an enqueued #{@klass} job with arguments #{@expected_arguments}\n\n" +
-          "found: #{@actual}"
+            "found: #{@actual}"
         end
 
         def matches? klass
           @klass = klass
-          @actual = klass.jobs.map { |job| job["args"] }
-          @actual.any? { |arguments| Array(@expected_arguments) == arguments }
+
+          if ::Sidekiq::Testing.disabled?
+            @actual = ::Sidekiq::Queue.new(@klass.get_sidekiq_options['queue']).map(&:args)
+          else
+            @actual = @klass.jobs.map { |job| job["args"] }
+          end
+          @actual.any? {|arguments| Array(@expected_arguments) == arguments }
         end
 
         def negative_failure_message


### PR DESCRIPTION
* Connected with #40
* Make the `have_delayed_job` matcher handle the case when the `Sidekiq::Testing` is disabled (the jobs are enqueued in redis)