### PR TITLE
allow passing an instance method to be_delayed matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ Object.delay_until(1.hour.from_now).is_nil? # delay until
 expect(Object.method :is_nil?).to be_delayed.until 1.hour.from_now
 Object.delay_until(1.hour.from_now).is_a? Object # delay until with argument
 expect(Object.method :is_a?).to be_delayed(Object).until 1.hour.from_now
+
+#Rails Mailer
+MyMailer.delay.some_mail
+expect(MyMailer.instance_method :some_mail).to be_delayed
 ```
 
 ### be_processed_in

--- a/lib/rspec/sidekiq/matchers/be_delayed.rb
+++ b/lib/rspec/sidekiq/matchers/be_delayed.rb
@@ -19,7 +19,7 @@ module RSpec
         end
 
         def failure_message
-          "expected #{@expected_method.receiver}.#{@expected_method.name} to " + description
+          "expected #{@expected_method_receiver}.#{@expected_method.name} to " + description
         end
 
         def for(interval)
@@ -29,6 +29,7 @@ module RSpec
 
         def matches?(expected_method)
           @expected_method = expected_method
+          @expected_method_receiver = @expected_method.is_a?(UnboundMethod) ? @expected_method.owner : @expected_method.receiver
 
           find_job @expected_method, @expected_arguments do |job|
             if @expected_interval
@@ -44,7 +45,7 @@ module RSpec
         end
 
         def failure_message_when_negated
-          "expected #{@expected_method.receiver}.#{@expected_method.name} to not " + description
+          "expected #{@expected_method_receiver}.#{@expected_method.name} to not " + description
         end
 
         def until(time)
@@ -57,7 +58,7 @@ module RSpec
         def find_job(method, arguments, &block)
           job = (::Sidekiq::Extensions::DelayedClass.jobs + ::Sidekiq::Extensions::DelayedModel.jobs + ::Sidekiq::Extensions::DelayedMailer.jobs).find do |job|
             yaml = YAML.load(job['args'].first)
-            @expected_method.receiver == yaml[0] && @expected_method.name == yaml[1] && (@expected_arguments <=> yaml[2]) == 0
+            @expected_method_receiver == yaml[0] && @expected_method.name == yaml[1] && (@expected_arguments <=> yaml[2]) == 0
           end
 
           yield job if block && job


### PR DESCRIPTION
to make it easier to test that a Rails Mailer mail got delayed


I'm not sure how to write a spec for this without adding ActiveMailer as a dependency?