### PR TITLE
Add flag to skip Batch stubs

### DIFF
--- a/lib/rspec/sidekiq/batch.rb
+++ b/lib/rspec/sidekiq/batch.rb
@@ -44,7 +44,9 @@ if defined? Sidekiq::Batch
   end
 
   RSpec.configure do |config|
-    config.before(:each) do
+    config.before(:each) do |example|
+      next if example.metadata[:stub_batches] == false
+
       if mocked_with_mocha?
         Sidekiq::Batch.stubs(:new) { RSpec::Sidekiq::NullBatch.new }
       else


### PR DESCRIPTION
We use matchers extensively, but `RSpec::Sidekiq::NullBatch` is problematic because we can't set expectations on batches. (Letting batches persist in test mode through https://github.com/guilleiguaran/fakeredis works well enough). This is just adding a flag to conditionally disable `NullBatch`.

If you have any ideas how to test this I'm all ears.