### PR TITLE
Matchers::HaveEnqueuedJob breaks on jobs with Hash arguments

### DIFF
--- a/lib/rspec/sidekiq/matchers/have_enqueued_job.rb
+++ b/lib/rspec/sidekiq/matchers/have_enqueued_job.rb
@@ -9,7 +9,7 @@ module RSpec
         attr_reader :klass, :expected_arguments, :actual
 
         def initialize(expected_arguments)
-          @expected_arguments = expected_arguments
+          @expected_arguments = normalize_arguments(expected_arguments)
         end
 
         def description
@@ -53,12 +53,24 @@ module RSpec
         end
 
         def job_arguments(hash)
-          hash['arguments'] || hash['args'] unless hash.is_a? Array
+          hash['arguments'] || hash['args'] if hash.is_a? Hash
         end
 
         def contain_exactly?(arguments)
           exactly = RSpec::Matchers::BuiltIn::ContainExactly.new(expected_arguments)
           exactly.matches?(arguments)
+        end
+
+        def normalize_arguments(args)
+          if args.is_a?(Array)
+            args.map{ |x| normalize_arguments(x) }
+          elsif args.is_a?(Hash)
+            args.each_with_object({}) do |(key, value), hash|
+              hash[key.to_s] = normalize_arguments(value)
+            end
+          else
+            args
+          end
         end
       end
     end

--- a/spec/rspec/sidekiq/matchers/have_enqueued_job_spec.rb
+++ b/spec/rspec/sidekiq/matchers/have_enqueued_job_spec.rb
@@ -1,14 +1,15 @@
 require 'spec_helper'
 
 RSpec.describe RSpec::Sidekiq::Matchers::HaveEnqueuedJob do
-  let(:argument_subject) { RSpec::Sidekiq::Matchers::HaveEnqueuedJob.new ['string', 1, true] }
-  let(:matcher_subject) { RSpec::Sidekiq::Matchers::HaveEnqueuedJob.new [be_a(String), be_a(Fixnum), true] }
+  let(:argument_subject) { RSpec::Sidekiq::Matchers::HaveEnqueuedJob.new worker_args }
+  let(:matcher_subject) { RSpec::Sidekiq::Matchers::HaveEnqueuedJob.new [be_a(String), be_a(Fixnum), true, be_a(Hash)] }
   let(:worker) { create_worker }
+  let(:worker_args) { ['string', 1, true, {key: 'value'}] }
   let(:active_job) { create_active_job :mailers }
   let(:resource) { TestResource.new }
 
   before(:each) do
-    worker.perform_async 'string', 1, true
+    worker.perform_async *worker_args
     active_job.perform_later 'someResource'
     active_job.perform_later(resource)
     TestActionMailer.testmail.deliver_later
@@ -18,11 +19,11 @@ RSpec.describe RSpec::Sidekiq::Matchers::HaveEnqueuedJob do
 
   describe 'expected usage' do
     it 'matches' do
-      expect(worker).to have_enqueued_job 'string', 1, true
+      expect(worker).to have_enqueued_job *worker_args
     end
 
     it 'matches on the global Worker queue' do
-      expect(Sidekiq::Worker).to have_enqueued_job 'string', 1, true
+      expect(Sidekiq::Worker).to have_enqueued_job *worker_args
     end
 
     it 'matches on an enqueued ActiveJob' do

--- a/spec/rspec/sidekiq/matchers/have_enqueued_job_spec.rb
+++ b/spec/rspec/sidekiq/matchers/have_enqueued_job_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe RSpec::Sidekiq::Matchers::HaveEnqueuedJob do
   let(:argument_subject) { RSpec::Sidekiq::Matchers::HaveEnqueuedJob.new worker_args }
   let(:matcher_subject) { RSpec::Sidekiq::Matchers::HaveEnqueuedJob.new [be_a(String), be_a(Fixnum), true, be_a(Hash)] }
   let(:worker) { create_worker }
-  let(:worker_args) { ['string', 1, true, {key: 'value'}] }
+  let(:worker_args) { ['string', 1, true, {key: 'value', nested: [{hash: true}]}] }
   let(:active_job) { create_active_job :mailers }
   let(:resource) { TestResource.new }
 
@@ -60,13 +60,13 @@ RSpec.describe RSpec::Sidekiq::Matchers::HaveEnqueuedJob do
 
   describe '#description' do
     it 'returns description' do
-      expect(argument_subject.description).to eq "have an enqueued #{worker} job with arguments [\"string\", 1, true, {:key=>\"value\"}]"
+      expect(argument_subject.description).to eq "have an enqueued #{worker} job with arguments [\"string\", 1, true, {\"key\"=>\"value\", \"nested\"=>[{\"hash\"=>true}]}]"
     end
   end
 
   describe '#failure_message' do
     it 'returns message' do
-      expect(argument_subject.failure_message).to eq "expected to have an enqueued #{worker} job with arguments [\"string\", 1, true, {:key=>\"value\"}]\n\nfound: [[\"string\", 1, true, {\"key\"=>\"value\"}]]"
+      expect(argument_subject.failure_message).to eq "expected to have an enqueued #{worker} job with arguments [\"string\", 1, true, {\"key\"=>\"value\", \"nested\"=>[{\"hash\"=>true}]}]\n\nfound: [[\"string\", 1, true, {\"key\"=>\"value\", \"nested\"=>[{\"hash\"=>true}]}]]"
     end
   end
 
@@ -104,7 +104,7 @@ RSpec.describe RSpec::Sidekiq::Matchers::HaveEnqueuedJob do
 
   describe '#failure_message_when_negated' do
     it 'returns message' do
-      expect(argument_subject.failure_message_when_negated).to eq "expected to not have an enqueued #{worker} job with arguments [\"string\", 1, true, {:key=>\"value\"}]"
+      expect(argument_subject.failure_message_when_negated).to eq "expected to not have an enqueued #{worker} job with arguments [\"string\", 1, true, {\"key\"=>\"value\", \"nested\"=>[{\"hash\"=>true}]}]"
     end
   end
 end

--- a/spec/rspec/sidekiq/matchers/have_enqueued_job_spec.rb
+++ b/spec/rspec/sidekiq/matchers/have_enqueued_job_spec.rb
@@ -60,13 +60,13 @@ RSpec.describe RSpec::Sidekiq::Matchers::HaveEnqueuedJob do
 
   describe '#description' do
     it 'returns description' do
-      expect(argument_subject.description).to eq "have an enqueued #{worker} job with arguments [\"string\", 1, true]"
+      expect(argument_subject.description).to eq "have an enqueued #{worker} job with arguments [\"string\", 1, true, {:key=>\"value\"}]"
     end
   end
 
   describe '#failure_message' do
     it 'returns message' do
-      expect(argument_subject.failure_message).to eq "expected to have an enqueued #{worker} job with arguments [\"string\", 1, true]\n\nfound: [[\"string\", 1, true]]"
+      expect(argument_subject.failure_message).to eq "expected to have an enqueued #{worker} job with arguments [\"string\", 1, true, {:key=>\"value\"}]\n\nfound: [[\"string\", 1, true, {\"key\"=>\"value\"}]]"
     end
   end
 
@@ -104,7 +104,7 @@ RSpec.describe RSpec::Sidekiq::Matchers::HaveEnqueuedJob do
 
   describe '#failure_message_when_negated' do
     it 'returns message' do
-      expect(argument_subject.failure_message_when_negated).to eq "expected to not have an enqueued #{worker} job with arguments [\"string\", 1, true]"
+      expect(argument_subject.failure_message_when_negated).to eq "expected to not have an enqueued #{worker} job with arguments [\"string\", 1, true, {:key=>\"value\"}]"
     end
   end
 end


### PR DESCRIPTION
I discovered recently that the have_enqueued_job matcher breaks when one of the job arguments is a hash (unless they all are). I think this has to do with the `any?` test in `map_arguments`.

I am opening a PR with the failing test, but hopefully I’ll have a complete patch shortly after lunch.