### PR TITLE
Add support for testing scheduled jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,12 +142,17 @@ AwesomeJob.perform_async 'Awesome', true
 expect(AwesomeJob).to have_enqueued_job('Awesome', true)
 ```
 
-#### Testing scheduled jobs with `perform_at`
-*Use a chainable matcher `#at`*
+#### Testing scheduled jobs
+*Use chainable matchers `#at` and `#in`*
 ```ruby
-Awesomejob.perform_at 5.minutes, 'Awesome', true
+Awesomejob.perform_at 5.minutes.from_now, 'Awesome', true
 # test with...
-expect(AwesomeJob).to have_enqueued_job('Awesome', true).at(5.minutes)
+expect(AwesomeJob).to have_enqueued_job('Awesome', true).at(5.minutes.from_now)
+```
+```ruby
+Awesomejob.perform_in 5.minutes, 'Awesome', true
+# test with...
+expect(AwesomeJob).to have_enqueued_job('Awesome', true).in(5.minutes)
 ```
 
 ## Example matcher usage

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ sidekiq_options unique: true
 expect(AwesomeJob).to be_unique
 it { is_expected.to be_unique }
 ```
+
 ### be_expired_in
 *Describes when a job should expire*
 ```ruby
@@ -139,6 +140,14 @@ it { is_expected.to_not be_expired_in 2.hours }
 AwesomeJob.perform_async 'Awesome', true
 # test with...
 expect(AwesomeJob).to have_enqueued_job('Awesome', true)
+```
+
+#### Testing scheduled jobs with `perform_at`
+*Use a chainable matcher `#at`*
+```ruby
+Awesomejob.perform_at 5.minutes, 'Awesome', true
+# test with...
+expect(AwesomeJob).to have_enqueued_job('Awesome', true).at(5.minutes)
 ```
 
 ## Example matcher usage

--- a/lib/rspec/sidekiq/batch.rb
+++ b/lib/rspec/sidekiq/batch.rb
@@ -59,6 +59,7 @@ if defined? Sidekiq::Batch
     end
   end
 
+  # :nocov:
   RSpec.configure do |config|
     config.before(:each) do |example|
       next if example.metadata[:stub_batches] == false
@@ -76,4 +77,5 @@ if defined? Sidekiq::Batch
   def mocked_with_mocha?
     Sidekiq::Batch.respond_to? :stubs
   end
+  # :nocov:
 end

--- a/spec/rspec/sidekiq/batch_spec.rb
+++ b/spec/rspec/sidekiq/batch_spec.rb
@@ -10,30 +10,61 @@ RSpec.describe 'Batch' do
 
   load File.expand_path(File.join(File.dirname(__FILE__), '../../../lib/rspec/sidekiq/batch.rb'))
 
+  describe 'NullObject' do
+    describe '#method_missing' do
+      it 'returns itself' do
+        batch = Sidekiq::Batch.new
+        expect(batch.non_existent_method).to eq(batch)
+      end
+    end
+  end
+
+  describe 'NullBatch' do
+  end
+
   describe 'NullStatus' do
+    let(:batch) {  Sidekiq::Batch.new }
+
+    subject { batch.status }
+
     describe '#total' do
       it 'returns 0 when no jobs' do
-        null_status = Sidekiq::Batch.new.status
-        expect(null_status.total).to eq(0)
+        expect(subject.total).to eq(0)
       end
 
       it 'returns 1 when 1 job' do
-        batch = Sidekiq::Batch.new
-
         batch.jobs do
           TestWorker.perform_async('5')
         end
 
-        null_status = batch.status
+        expect(subject.total).to eq(1)
+      end
+    end
 
-        expect(null_status.total).to eq(1)
+    describe '#failures' do
+      it 'returns 0' do
+        expect(subject.failures).to eq(0)
       end
     end
 
     describe '#bid' do
       it 'returns a bid' do
-        null_status = Sidekiq::Batch.new
-        expect(null_status.bid).to_not be_nil
+        expect(subject.bid).to_not be_nil
+      end
+    end
+
+    describe '#join' do
+      class MyCallback
+        def on_event(status, options); end
+      end
+
+      before(:each) do
+        batch.on(:event, MyCallback, my_arg: 42)
+      end
+
+      it 'executes callbacks' do
+        expect_any_instance_of(MyCallback).to receive(:on_event).with(subject, { my_arg: 42 })
+        subject.join
       end
     end
   end

--- a/spec/rspec/sidekiq/matchers/be_unique_spec.rb
+++ b/spec/rspec/sidekiq/matchers/be_unique_spec.rb
@@ -38,6 +38,12 @@ RSpec.describe RSpec::Sidekiq::Matchers::BeUnique do
         end
       end
     end
+
+    describe '#description' do
+      it 'returns description' do
+        expect(subject.description).to eq 'be unique in the queue'
+      end
+    end
   end
 
   context 'a sidekiq-enterprise scheduled worker' do


### PR DESCRIPTION
Allow you to test scheduled jobs chaining `#at` to `#have_enqueued_job`.

```ruby
Awesomejob.perform_at 5.minutes, 'Awesome', true
# test with...
expect(AwesomeJob).to have_enqueued_job('Awesome', true).at(5.minutes)
```

I don't know if this is the best approach, but it's a start.
Suggestions are welcome.