### PR TITLE
Add support for Sidekiq Enterprise

### DIFF
--- a/lib/rspec/sidekiq/matchers/be_unique.rb
+++ b/lib/rspec/sidekiq/matchers/be_unique.rb
@@ -16,8 +16,26 @@ module RSpec
 
         def matches?(job)
           @klass = job.is_a?(Class) ? job : job.class
-          @actual = @klass.get_sidekiq_options['unique']
+          @actual = @klass.get_sidekiq_options[unique_key]
           [true, :all].include?(@actual)
+        end
+
+        def unique_key
+          if sidekiq_enterprise?
+            'unique_for'
+          elsif sidekiq_unique_jobs?
+            'unique'
+          else
+            fail "No gem included for uniquing"
+          end
+        end
+
+        def sidekiq_enterprise?
+          defined? ::Sidekiq::Enterprise
+        end
+
+        def sidekiq_unique_jobs?
+          defined? ::SidekiqUniqueJobs
         end
 
         def failure_message_when_negated

--- a/lib/rspec/sidekiq/matchers/be_unique.rb
+++ b/lib/rspec/sidekiq/matchers/be_unique.rb
@@ -17,7 +17,15 @@ module RSpec
         def matches?(job)
           @klass = job.is_a?(Class) ? job : job.class
           @actual = @klass.get_sidekiq_options[unique_key]
-          [true, :all].include?(@actual)
+          valid_value?
+        end
+
+        def valid_value?
+          if sidekiq_enterprise?
+            @actual > 0
+          elsif sidekiq_unique_jobs?
+            [true, :all].include?(@actual)
+          end
         end
 
         def unique_key

--- a/spec/rspec/sidekiq/matchers/be_unique_spec.rb
+++ b/spec/rspec/sidekiq/matchers/be_unique_spec.rb
@@ -2,6 +2,9 @@ require 'spec_helper'
 
 RSpec.describe RSpec::Sidekiq::Matchers::BeUnique do
   shared_context 'a unique worker' do
+    before do
+      stub_const("SidekiqUniqueJobs", true)
+    end
     before(:each) { subject.matches? @worker }
 
     describe 'expected usage' do
@@ -57,6 +60,34 @@ RSpec.describe RSpec::Sidekiq::Matchers::BeUnique do
   describe '#failure_message_when_negated' do
     it 'returns message' do
       expect(subject.failure_message_when_negated).to eq "expected #{@worker} to not be unique in the queue"
+    end
+  end
+
+  describe '#unique_key' do
+    context "with Sidekiq Enterprise" do
+      before do
+        stub_const("Sidekiq::Enterprise", true)
+      end
+
+      it "returns the correct key" do
+        expect(subject.unique_key).to eq('unique_for')
+      end
+    end
+
+    context "with sidekiq-unique-jobs" do
+      before do
+        stub_const("SidekiqUniqueJobs", true)
+      end
+
+      it "returns the correct key" do
+        expect(subject.unique_key).to eq('unique')
+      end
+    end
+
+    context "without a uniquing solution" do
+      it "raises an exception" do
+        expect{subject.unique_key}.to raise_error
+      end
     end
   end
 end


### PR DESCRIPTION
Sidekiq Enterprise uses the `unique_for` option, not `unique`.

This PR will detect which Gem a user is using for the `be_unique` matcher.

It also adds a `for` matcher so you can specify the interval.