### PR TITLE
only depend on rspec-core

### DIFF
--- a/rspec-sidekiq.gemspec
+++ b/rspec-sidekiq.gemspec
@@ -11,9 +11,8 @@ Gem::Specification.new do |s|
   s.description = 'Simple testing of Sidekiq jobs via a collection of matchers and helpers'
   s.license     = 'MIT'
 
-  s.add_dependency 'rspec', '~> 3.0', '>= 3.0.0'
+  s.add_dependency 'rspec-core', '~> 3.0', '>= 3.0.0'
   s.add_dependency 'sidekiq', '>= 2.4.0'
-  s.add_dependency 'rspec-rails', '>= 3.4.0'
 
   s.add_development_dependency 'coveralls', '~> 0.8', '>= 0.8.0'
   s.add_development_dependency 'fuubar', '~> 2.0', '>= 2.0.0'


### PR DESCRIPTION
- this way users of rspec-sidekiq can properly upgrade their version of rspec/rspec-rails depending on which "meta gem" they use.

PR for #94 

I removed the rspec-rails dependency (As it is not needed) instead specs should be written around that feature and travis CI's gemfile matrix should be used to test with and without rspec-rails.