### PR TITLE
Pass exception to within_sidekiq_retries_exhausted_block

### DIFF
--- a/lib/rspec/sidekiq/helpers/within_sidekiq_retries_exhausted_block.rb
+++ b/lib/rspec/sidekiq/helpers/within_sidekiq_retries_exhausted_block.rb
@@ -1,18 +1,22 @@
 module Sidekiq
   module Worker
     module ClassMethods
-      def within_sidekiq_retries_exhausted_block(user_msg = {}, &block)
+      def within_sidekiq_retries_exhausted_block(user_msg = {}, exception = default_retries_exhausted_exception, &block)
         block.call
-        sidekiq_retries_exhausted_block.call default_retries_exhausted_args.merge(user_msg)
+        sidekiq_retries_exhausted_block.call default_retries_exhausted_message.merge(user_msg)
       end
 
-      def default_retries_exhausted_args
+      def default_retries_exhausted_message
         {
           'queue' => get_sidekiq_options[:worker],
           'class' => name,
           'args' => [],
           'error_message' => 'An error occured'
         }
+      end
+
+      def default_retries_exhausted_exception
+        StandardError.new('An error occured')
       end
     end
   end

--- a/spec/rspec/sidekiq/helpers/retries_exhausted_spec.rb
+++ b/spec/rspec/sidekiq/helpers/retries_exhausted_spec.rb
@@ -2,9 +2,10 @@ require 'spec_helper'
 
 RSpec.describe 'Retries Exhausted block' do
   class FooClass < TestWorkerAlternative
-    sidekiq_retries_exhausted do |msg|
+    sidekiq_retries_exhausted do |msg, exception|
       bar('hello')
       foo(msg)
+      baz(exception)
     end
 
     def self.bar(input)
@@ -12,17 +13,28 @@ RSpec.describe 'Retries Exhausted block' do
 
     def self.foo(msg)
     end
+
+    def self.baz(exception)
+    end
   end
 
   it 'executes whatever is within the block' do
     FooClass.within_sidekiq_retries_exhausted_block { expect(FooClass).to receive(:bar).with('hello') }
   end
 
-  it 'passes arguments to the block' do
+  it 'passes message and exception to the block' do
     args = { 'args' => ['a', 'b']}
-    FooClass.within_sidekiq_retries_exhausted_block(args) do
-      expect(FooClass).to receive(:foo).with(FooClass.default_retries_exhausted_args.merge(args))
+    exception = StandardError.new('something went wrong')
+    FooClass.within_sidekiq_retries_exhausted_block(args, exception) do
+      expect(FooClass).to receive(:foo).with(FooClass.default_retries_exhausted_message.merge(args))
+      expect(FooClass).to receive(:baz).with(exception)
     end
   end
 
+  it 'sets a default value for the message and exception' do
+    FooClass.within_sidekiq_retries_exhausted_block do
+      expect(FooClass).to receive(:foo).with(FooClass.default_retries_exhausted_message)
+      expect(FooClass).to receive(:baz).with(FooClass.default_retries_exhausted_exception)
+    end
+  end
 end


### PR DESCRIPTION
Currently this method doesn't allow for sending an exception, but
sidekiq will send it along with the block.

https://github.com/mperham/sidekiq/blob/35a7962093040784b48498e012bdff380ef991a8/lib/sidekiq/middleware/server/retry_jobs.rb#L143