### PR TITLE
Rely on all of RSpec in development

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,13 @@ rvm:
   - 2.2
   - jruby
   - rbx-2
+  
 script: "bundle exec rspec spec"
+
 before_install:
   - gem install bundler
+
 matrix:
   allow_failures:
+    - rvm: jruby
     - rvm: rbx-2

--- a/rspec-sidekiq.gemspec
+++ b/rspec-sidekiq.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rspec-core', '~> 3.0', '>= 3.0.0'
   s.add_dependency 'sidekiq', '>= 2.4.0'
 
+  s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'coveralls', '~> 0.8', '>= 0.8.0'
   s.add_development_dependency 'fuubar', '~> 2.0', '>= 2.0.0'
   s.add_development_dependency 'activejob', '~> 4.2', '>= 4.0.0'


### PR DESCRIPTION
Without this, we don't load rspec-mocks or rspec-expectations which
means none of the tests can run. Previously this worked because fuubar
required the full rspec library, but as of 2.2 it only requires
rspec-core.

https://github.com/thekompanee/fuubar/commit/a6b65681ee3a91033f7710287a20c63c5a903d07

This only adds a development dependency, so it won't undo the work in #96 