### PR TITLE
Add a note about have_enqueued_job and rspec-rails to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,10 @@ it { is_expected.to_not be_expired_in 2.hours }
 
 ### have_enqueued_job
 *Describes that there should be an enqueued job with the specified arguments*
+
+**Note:** When using rspec-rails >= 3.4, use `have_enqueued_sidekiq_job` instead to
+prevent a name clash with rspec-rails' ActiveJob matcher.
+
 ```ruby
 AwesomeJob.perform_async 'Awesome', true
 # test with...


### PR DESCRIPTION
#95 introduced a change which allows to use rspec-sidekiq alongside rspec-rails.  This PR adds a note to the README.md regarding this.