### PR TITLE
Use default arguments for NullStatus initialization

### DIFF
--- a/lib/rspec/sidekiq/batch.rb
+++ b/lib/rspec/sidekiq/batch.rb
@@ -33,9 +33,9 @@ if defined? Sidekiq::Batch
       class NullStatus < NullObject
         attr_reader :bid
 
-        def initialize(bid, callbacks)
-          @bid = bid
-          @callbacks = callbacks
+        def initialize(bid = nil, callbacks = nil)
+          @bid = bid || SecureRandom.hex(8)
+          @callbacks = callbacks || []
         end
 
         def failures

--- a/lib/rspec/sidekiq/batch.rb
+++ b/lib/rspec/sidekiq/batch.rb
@@ -33,9 +33,9 @@ if defined? Sidekiq::Batch
       class NullStatus < NullObject
         attr_reader :bid
 
-        def initialize(bid = nil, callbacks = nil)
-          @bid = bid || SecureRandom.hex(8)
-          @callbacks = callbacks || []
+        def initialize(bid = SecureRandom.hex(8), callbacks = [])
+          @bid = bid
+          @callbacks = callbacks
         end
 
         def failures

--- a/spec/rspec/sidekiq/batch_spec.rb
+++ b/spec/rspec/sidekiq/batch_spec.rb
@@ -67,5 +67,11 @@ RSpec.describe 'Batch' do
         subject.join
       end
     end
+
+    describe '#initialize' do
+      it 'uses default argument values when none are provided' do
+        expect { Sidekiq::Batch::Status.new }.to_not raise_error
+      end
+    end
   end
 end


### PR DESCRIPTION
- this prevents an ArgumentError when NullStatus#new is called in lib/rspec/sidekiq/batch.rb:71