### PR TITLE
Ruby 2.4 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: ruby
 rvm:
-  - 2.1
   - 2.2
   - 2.3
+  - 2.4.1
   - jruby
   - rbx-2
   

--- a/lib/rspec/sidekiq/matchers/be_retryable.rb
+++ b/lib/rspec/sidekiq/matchers/be_retryable.rb
@@ -11,7 +11,7 @@ module RSpec
         end
 
         def description
-          if @expected_retry.is_a?(Fixnum)
+          if @expected_retry.is_a?(Numeric)
             "retry #{@expected_retry} times"    # retry: 5
           elsif @expected_retry
             'retry the default number of times' # retry: true

--- a/lib/rspec/sidekiq/matchers/save_backtrace.rb
+++ b/lib/rspec/sidekiq/matchers/save_backtrace.rb
@@ -11,7 +11,7 @@ module RSpec
         end
 
         def description
-          if @expected_backtrace.is_a?(Fixnum)
+          if @expected_backtrace.is_a?(Numeric)
             "save #{@expected_backtrace} lines of error backtrace" # backtrace: 5
           elsif @expected_backtrace
             'save error backtrace' # backtrace: true


### PR DESCRIPTION
Changes to support ruby 2.4
* Test against 2.4 and not 2.1
* Use `Numeric` instead of `Fixnum`