### PR TITLE
Avoid methods from ActiveSupport, which is not required at runtime

### DIFF
--- a/lib/rspec/sidekiq/matchers/have_enqueued_job.rb
+++ b/lib/rspec/sidekiq/matchers/have_enqueued_job.rb
@@ -43,7 +43,7 @@ module RSpec
         end
 
         def present?(arguments, options)
-          find_job(arguments, options).present?
+          !!find_job(arguments, options)
         end
 
         private
@@ -137,7 +137,7 @@ module RSpec
         def unwrapped_job_options(jobs)
           jobs = jobs.values if jobs.is_a?(Hash)
           jobs.flatten.map do |job|
-            job.slice('at')
+            { 'at' => job['at'] }
           end
         end
 


### PR DESCRIPTION
Version 3.0.0 included #109 which added the private `unwrapped_job_options` method:

```ruby
def unwrapped_job_options(jobs)
  jobs = jobs.values if jobs.is_a?(Hash)
  jobs.flatten.map do |job|
    job.slice('at')
  end
end
```

The method relies on `Hash#slice`, which is in ActiveSupport but not Ruby. This broke one of my gem's test suites because the `activesupport` gem isn't declared as a runtime dependency, only a development dependency, causing a `NoMethodError`:

```
Failure/Error: expect(FooJob).to have_enqueued_job(1)

NoMethodError:
  undefined method `slice' for #<Hash:0x000000027b2df0>
# ./gemfiles/vendor/bundle/ruby/2.0.0/gems/rspec-sidekiq-3.0.0/lib/rspec/sidekiq/matchers/have_enqueued_job.rb:140:in `block in unwrapped_job_options'
```

I would actually like to avoid _any_ runtime gem dependencies on ActiveSupport or other Rails libraries, since Sidekiq itself does not require Rails.

In addition to the use of `slice`, `present?` was also introduced in #81, which is only in ActiveSupport.

This PR corrects both problems.

It would be nice to have this be caught by the test suite, but I don't see a simple way of avoiding it because of the global nature of `require`. The reason it doesn't fail in this gem's own suite is because `activejob` is a development dependency, presumably to allow test coverage of ActiveJob support.