### PR TITLE
Make deprecation warning actionable

### DIFF
--- a/lib/rspec/sidekiq/matchers/have_enqueued_job.rb
+++ b/lib/rspec/sidekiq/matchers/have_enqueued_job.rb
@@ -2,13 +2,12 @@ module RSpec
   module Sidekiq
     module Matchers
       def have_enqueued_job(*expected_arguments)
+        if __callee__ == :have_enqueued_job && Gem::Dependency.new('rspec-rails', '>= 3.4.0').matching_specs.max_by(&:version)
+          warn "[DEPRECATION] `have_enqueued_job` is deprecated.  Please use `have_enqueued_sidekiq_job` instead."
+        end
         HaveEnqueuedJob.new expected_arguments
       end
-
-      if Gem::Dependency.new('rspec-rails', '>= 3.4.0').matching_specs.max_by(&:version)
-        warn "[DEPRECATION] `have_enqueued_job` is deprecated.  Please use `have_enqueued_sidekiq_job` instead."
-        alias have_enqueued_sidekiq_job have_enqueued_job
-      end
+      alias :have_enqueued_sidekiq_job :have_enqueued_job
 
       class JobOptionParser
         attr_reader :job

--- a/lib/rspec/sidekiq/version.rb
+++ b/lib/rspec/sidekiq/version.rb
@@ -1,5 +1,5 @@
 module RSpec
   module Sidekiq
-    VERSION = '3.0.1'
+    VERSION = '3.0.2'
   end
 end

--- a/rspec-sidekiq.gemspec
+++ b/rspec-sidekiq.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'fuubar', '~> 2.0', '>= 2.0.0'
   s.add_development_dependency 'activejob', '~> 4.2', '>= 4.0.0'
   s.add_development_dependency 'actionmailer', '~> 4.2', '>= 4.0.0'
+  s.add_development_dependency 'activerecord', '~> 4.2', '>= 4.0.0'
 
 
   s.files = Dir['.gitattributes'] +

--- a/spec/rspec/sidekiq/version_spec.rb
+++ b/spec/rspec/sidekiq/version_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
 
 RSpec.describe RSpec::Sidekiq::VERSION do
-  it { is_expected.to eq('3.0.1') }
+  it { is_expected.to eq('3.0.2') }
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@ require 'rspec-sidekiq'
 
 require 'active_job'
 require 'action_mailer'
+require 'active_record'
 
 require_relative 'support/init'
 
@@ -17,8 +18,12 @@ SimpleCov.start
 
 RSpec.configure do |config|
   config.disable_monkey_patching!
-
   config.include RSpec::Sidekiq::Spec::Support::Factories
 end
 
 ActiveJob::Base.queue_adapter = :sidekiq
+
+if Gem::Dependency.new('sidekiq', '>= 5.0.0').matching_specs.any?
+  ActiveSupport.run_load_hooks(:active_record, ActiveRecord::Base)
+  Sidekiq::Extensions.enable_delay!
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,10 +10,9 @@ require 'active_record'
 
 require_relative 'support/init'
 
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
-  Coveralls::SimpleCov::Formatter,
-  SimpleCov::Formatter::HTMLFormatter
-]
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
+  [Coveralls::SimpleCov::Formatter, SimpleCov::Formatter::HTMLFormatter]
+)
 SimpleCov.start
 
 RSpec.configure do |config|


### PR DESCRIPTION
As it currently stands, this deprecation warning is un-actionable. The warning suggests a way to "resolve" the deprecation but that's not exactly right.