### PR TITLE
Fix tests and deprecations with Sidekiq 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ rvm:
   - 2.4.1
   - jruby
   - rbx-2
-  
+
 script: "bundle exec rspec spec"
 
 before_install:
@@ -18,3 +18,5 @@ matrix:
   include:
     - rvm: 2.0
       gemfile: gemfiles/ruby20.gemfile
+    - rmv: 2.4
+      gemfile: gemfiles/sidekiq4.gemfile

--- a/gemfiles/sidekiq4.gemfile
+++ b/gemfiles/sidekiq4.gemfile
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 
 gem 'sidekiq', '< 5'
-gem 'nokogiri', '< 1.7'
 
 gemspec :path => '../'

--- a/lib/rspec/sidekiq/matchers/have_enqueued_job.rb
+++ b/lib/rspec/sidekiq/matchers/have_enqueued_job.rb
@@ -1,13 +1,13 @@
 module RSpec
   module Sidekiq
     module Matchers
-      def have_enqueued_job(*expected_arguments)
+      def have_enqueued_sidekiq_job(*expected_arguments)
         HaveEnqueuedJob.new expected_arguments
       end
 
-      if Gem::Dependency.new('rspec-rails', '>= 3.4.0').matching_specs.max_by(&:version)
+      def have_enqueued_job(*expected_arguments)
         warn "[DEPRECATION] `have_enqueued_job` is deprecated.  Please use `have_enqueued_sidekiq_job` instead."
-        alias have_enqueued_sidekiq_job have_enqueued_job
+        have_enqueued_sidekiq_job(expected_arguments)
       end
 
       class JobOptionParser

--- a/rspec-sidekiq.gemspec
+++ b/rspec-sidekiq.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'fuubar', '~> 2.0', '>= 2.0.0'
   s.add_development_dependency 'activejob', '~> 4.2', '>= 4.0.0'
   s.add_development_dependency 'actionmailer', '~> 4.2', '>= 4.0.0'
+  s.add_development_dependency 'activerecord', '~> 4.2', '>= 4.0.0'
 
 
   s.files = Dir['.gitattributes'] +

--- a/spec/rspec/sidekiq/matchers/have_enqueued_job_spec.rb
+++ b/spec/rspec/sidekiq/matchers/have_enqueued_job_spec.rb
@@ -21,11 +21,11 @@ RSpec.describe RSpec::Sidekiq::Matchers::HaveEnqueuedJob do
   describe 'expected usage' do
     context 'Sidekiq' do
       it 'matches' do
-        expect(worker).to have_enqueued_job *worker_args
+        expect(worker).to have_enqueued_sidekiq_job *worker_args
       end
 
       it 'matches on the global Worker queue' do
-        expect(Sidekiq::Worker).to have_enqueued_job *worker_args
+        expect(Sidekiq::Worker).to have_enqueued_sidekiq_job *worker_args
       end
 
       context 'perform_in' do
@@ -36,7 +36,7 @@ RSpec.describe RSpec::Sidekiq::Matchers::HaveEnqueuedJob do
         end
 
         it 'matches on an scheduled job with #perform_in' do
-          expect(worker).to have_enqueued_job(*worker_args_in).in(interval)
+          expect(worker).to have_enqueued_sidekiq_job(*worker_args_in).in(interval)
         end
       end
 
@@ -48,24 +48,24 @@ RSpec.describe RSpec::Sidekiq::Matchers::HaveEnqueuedJob do
         end
 
         it 'matches on an scheduled job with #perform_at' do
-          expect(worker).to have_enqueued_job(*worker_args_at).at(tomorrow)
+          expect(worker).to have_enqueued_sidekiq_job(*worker_args_at).at(tomorrow)
         end
       end
     end
 
     context 'ActiveJob' do
       it 'matches on an enqueued ActiveJob' do
-        expect(Sidekiq::Worker).to have_enqueued_job 'someResource'
+        expect(Sidekiq::Worker).to have_enqueued_sidekiq_job 'someResource'
       end
 
       it 'matches on an enqueued ActiveJob by global_id' do
-        expect(Sidekiq::Worker).to have_enqueued_job('_aj_globalid' => resource.to_global_id.uri.to_s)
+        expect(Sidekiq::Worker).to have_enqueued_sidekiq_job('_aj_globalid' => resource.to_global_id.uri.to_s)
       end
     end
 
     context 'ActionMailer' do
       it 'matches on ActionMailer Job' do
-        expect(Sidekiq::Worker).to have_enqueued_job(
+        expect(Sidekiq::Worker).to have_enqueued_sidekiq_job(
           'TestActionMailer',
           'testmail',
           'deliver_now'
@@ -73,7 +73,7 @@ RSpec.describe RSpec::Sidekiq::Matchers::HaveEnqueuedJob do
       end
 
       it 'matches on ActionMailer with a resource Job' do
-        expect(Sidekiq::Worker).to have_enqueued_job(
+        expect(Sidekiq::Worker).to have_enqueued_sidekiq_job(
           'TestActionMailer',
           'testmail',
           'deliver_now',
@@ -83,9 +83,19 @@ RSpec.describe RSpec::Sidekiq::Matchers::HaveEnqueuedJob do
     end
   end
 
+  describe '#have_enqueued_sidekiq_job' do
+    it 'returns instance' do
+      expect(have_enqueued_sidekiq_job).to be_a RSpec::Sidekiq::Matchers::HaveEnqueuedJob
+    end
+  end
+
   describe '#have_enqueued_job' do
     it 'returns instance' do
       expect(have_enqueued_job).to be_a RSpec::Sidekiq::Matchers::HaveEnqueuedJob
+    end
+
+    it 'provides deprecation warning' do
+      expect { have_enqueued_job }.to output(/[DEPRECATION]/).to_stderr
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,10 +9,9 @@ require 'action_mailer'
 
 require_relative 'support/init'
 
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
-  Coveralls::SimpleCov::Formatter,
-  SimpleCov::Formatter::HTMLFormatter
-]
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
+  [Coveralls::SimpleCov::Formatter, SimpleCov::Formatter::HTMLFormatter]
+)
 SimpleCov.start
 
 RSpec.configure do |config|
@@ -22,3 +21,9 @@ RSpec.configure do |config|
 end
 
 ActiveJob::Base.queue_adapter = :sidekiq
+
+if Gem::Dependency.new('sidekiq', '>= 5.0.0').matching_specs.any?
+  require 'active_record'
+  ActiveSupport.run_load_hooks(:active_record, ActiveRecord::Base)
+  Sidekiq::Extensions.enable_delay!
+end


### PR DESCRIPTION
* Turn on BeDelayed with Sidekiq versions >= 5
* Test against old versions of Sidekiq
* Fix deprecation warning to only show on calling deprecated method(s)