### PR TITLE
Enable Sidekiq delay extension for >5.0.0

### DIFF
--- a/rspec-sidekiq.gemspec
+++ b/rspec-sidekiq.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'fuubar', '~> 2.0', '>= 2.0.0'
   s.add_development_dependency 'activejob', '~> 4.2', '>= 4.0.0'
   s.add_development_dependency 'actionmailer', '~> 4.2', '>= 4.0.0'
+  s.add_development_dependency 'activerecord', '~> 4.2', '>= 4.0.0'
 
 
   s.files = Dir['.gitattributes'] +

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,10 +9,9 @@ require 'action_mailer'
 
 require_relative 'support/init'
 
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
-  Coveralls::SimpleCov::Formatter,
-  SimpleCov::Formatter::HTMLFormatter
-]
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new(
+  [Coveralls::SimpleCov::Formatter, SimpleCov::Formatter::HTMLFormatter]
+)
 SimpleCov.start
 
 RSpec.configure do |config|
@@ -22,3 +21,9 @@ RSpec.configure do |config|
 end
 
 ActiveJob::Base.queue_adapter = :sidekiq
+
+if Gem::Dependency.new('sidekiq', '>= 5.0.0').matching_specs.any?
+  require 'active_record'
+  ActiveSupport.run_load_hooks(:active_record, ActiveRecord::Base)
+  Sidekiq::Extensions.enable_delay!
+end


### PR DESCRIPTION
As per https://github.com/philostler/rspec-sidekiq/pull/130#issuecomment-306683365 Sidekiq >5.0.0 is the delayed extension disabled by default. We therefore enable the extension to test properly.

**Note:** Some tests will still fail since Sidekiq >5.0.0 requires Ruby >=2.2.2. The PR https://github.com/philostler/rspec-sidekiq/pull/130 should address those failures.