### PR TITLE
Re-splat arguments for the have_enqueued_job alias

### DIFF
--- a/lib/rspec/sidekiq/matchers/have_enqueued_job.rb
+++ b/lib/rspec/sidekiq/matchers/have_enqueued_job.rb
@@ -7,7 +7,7 @@ module RSpec
 
       def have_enqueued_job(*expected_arguments)
         warn "[DEPRECATION] `have_enqueued_job` is deprecated.  Please use `have_enqueued_sidekiq_job` instead."
-        have_enqueued_sidekiq_job(expected_arguments)
+        have_enqueued_sidekiq_job(*expected_arguments)
       end
 
       class JobOptionParser

--- a/spec/rspec/sidekiq/matchers/have_enqueued_job_spec.rb
+++ b/spec/rspec/sidekiq/matchers/have_enqueued_job_spec.rb
@@ -97,6 +97,10 @@ RSpec.describe RSpec::Sidekiq::Matchers::HaveEnqueuedJob do
     it 'provides deprecation warning' do
       expect { have_enqueued_job }.to output(/[DEPRECATION]/).to_stderr
     end
+
+    it 'matches the same way have_enqueued_sidekiq_job does' do
+      expect(worker).to have_enqueued_job *worker_args
+    end
   end
 
   describe '#description' do


### PR DESCRIPTION
This makes sure that an extra level of array wrapping isn't added for tests which use the now-deprecated have_enqueued_job, which causes test failures.