### PR TITLE
Add description attr_accessor to NullBatch

### DIFF
--- a/lib/rspec/sidekiq/batch.rb
+++ b/lib/rspec/sidekiq/batch.rb
@@ -10,6 +10,7 @@ if defined? Sidekiq::Batch
       end
 
       class NullBatch < NullObject
+        attr_accessor :description
         attr_reader :bid
 
         def initialize(bid = nil)


### PR DESCRIPTION
Enables `sidekiq_batch#description=`
```ruby
batch = Sidekiq::Batch.new
batch.description = "Batch description (this is optional)"
batch.on(:success, MyCallback, :to => user.email)
batch.jobs do
  rows.each { |row| RowWorker.perform_async(row) }
end
```
Reference: https://github.com/mperham/sidekiq/wiki/Batches