### PR TITLE
Support Class#method notation in batch callback

### DIFF
--- a/spec/rspec/sidekiq/batch_spec.rb
+++ b/spec/rspec/sidekiq/batch_spec.rb
@@ -58,12 +58,18 @@ RSpec.describe 'Batch' do
         def on_event(status, options); end
       end
 
+      class OtherCallback
+        def foo(status, options); end
+      end
+
       before(:each) do
         batch.on(:event, MyCallback, my_arg: 42)
+        batch.on(:event, 'OtherCallback#foo', my_arg: 23)
       end
 
       it 'executes callbacks' do
         expect_any_instance_of(MyCallback).to receive(:on_event).with(subject, { my_arg: 42 })
+        expect_any_instance_of(OtherCallback).to receive(:foo).with(subject, { my_arg: 23 })
         subject.join
       end
     end


### PR DESCRIPTION
Sidekiq Pro batch callback feature supports the `Class#method` notation when registering a callback. It's documented [here](https://github.com/mperham/sidekiq/wiki/Batches#callbacks).

This commit adds support for it in `NullBatch`.