### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ rspec-sidekiq requires ```sidekiq/testing``` by default so there is no need to i
 ## Configuration
 If you wish to modify the default behaviour, add the following to your ```spec_helper.rb``` file
 ```ruby
+require 'rspec-sidekiq'
+
 RSpec::Sidekiq.configure do |config|
   # Clears all job queues before each example
   config.clear_all_enqueued_jobs = true # default => true


### PR DESCRIPTION
We should update the README#Configuration.

In my case i had to explicitally ```require 'rspec-sidekiq'``` in the spec_helper to avoid the following error:

```console
NameError:
  uninitialized constant RSpec::Sidekiq
```