### PR TITLE
Fix array arguments matching

### DIFF
--- a/lib/rspec/sidekiq/matchers/have_enqueued_job.rb
+++ b/lib/rspec/sidekiq/matchers/have_enqueued_job.rb
@@ -148,7 +148,7 @@ module RSpec
             end
           else
             map_arguments(jobs)
-          end.map { |job| job.flatten }
+          end.first
         end
 
         def map_arguments(job)

--- a/spec/rspec/sidekiq/matchers/have_enqueued_job_spec.rb
+++ b/spec/rspec/sidekiq/matchers/have_enqueued_job_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe RSpec::Sidekiq::Matchers::HaveEnqueuedJob do
       expected to have an enqueued #{worker} job
         arguments: [\"string\", 1, true, {\"key\"=>\"value\", \"bar\"=>\"foo\", \"nested\"=>[{\"hash\"=>true}]}]
       found
-        arguments: [[\"string\", 1, true, {\"key\"=>\"value\", \"bar\"=>\"foo\", \"nested\"=>[{\"hash\"=>true}]}]]
+        arguments: [\"string\", 1, true, {\"key\"=>\"value\", \"bar\"=>\"foo\", \"nested\"=>[{\"hash\"=>true}]}]
       eos
     end
   end


### PR DESCRIPTION
The workers may have arrays of integers as arguments.

This gem expectation fails if we are checking for something like 
```
expect(SomeWorker).to have_enqueued_sidekiq_job([1, 2], "something")
```